### PR TITLE
streamin_magicblast can now in/exclude (closes #13)

### DIFF
--- a/streamin_magicblast.py
+++ b/streamin_magicblast.py
@@ -36,13 +36,11 @@ def read_stdin(score_cutoff, match_behaviour):
                 sys.stdout.write(line)
                 sys.stdout.flush()
         elif la[2] == "*":
-            print(la)
             if match_behaviour == "exclude":
                 sys.stdout.write(line)
                 sys.stdout.flush()
             else:
                 pass
-            sys.exit()
 
         else:
             # todo: this should contain the output for the header

--- a/streamin_magicblast.py
+++ b/streamin_magicblast.py
@@ -3,7 +3,7 @@ import argparse
 from textwrap import dedent
 
 
-def check_cutoff(seq_read, score_cutoff):
+def check_cutoff(seq_read, score_cutoff, match_behaviour):
     length = len(seq_read[9])
     found_score = int(seq_read[12].split(":")[-1])
     score_cutoff_list = score_cutoff.split(",")
@@ -12,12 +12,17 @@ def check_cutoff(seq_read, score_cutoff):
         target_score = (score_cutoff_list[0]*length) + score_cutoff_list[1]
     else:
         target_score = score_cutoff_list[0]
-    if found_score >= target_score:
-        return True
-    return False
+    if match_behaviour == "include":
+        if found_score >= target_score:
+            return True
+        return False
+    if match_behaviour == "exclude":
+        if found_score <= target_score:
+            return True
+        return False
 
 
-def read_stdin(score_cutoff):
+def read_stdin(score_cutoff, match_behaviour):
     """
     Read stdin() and check whether
     a) line is a read or not
@@ -27,9 +32,18 @@ def read_stdin(score_cutoff):
         la = line.strip().split("\t")
         if (len(la)) == 14:
             # yep, this is a read
-            if check_cutoff(la, score_cutoff):
+            if check_cutoff(la, score_cutoff, match_behaviour):
                 sys.stdout.write(line)
                 sys.stdout.flush()
+        elif la[2] == "*":
+            print(la)
+            if match_behaviour == "exclude":
+                sys.stdout.write(line)
+                sys.stdout.flush()
+            else:
+                pass
+            sys.exit()
+
         else:
             # todo: this should contain the output for the header
             # lines
@@ -43,7 +57,9 @@ def __main__():
         This takes a streamed SAM file as input and filters alignments based
         on the alignment score. The score can be given either as a uniform
         score or as a linear function of the form score = a * Length + b
-        where Length describes the read length
+        where Length describes the read length.
+        You can also decide whether reads that fulfill your score threshold
+        should be included or excluded.
         """)
         parser = argparse.ArgumentParser(
             description=description,
@@ -54,9 +70,19 @@ def __main__():
         """)
         parser.add_argument('-s', '--score', default="0.001353,25",
                             help=score_help)
+        match_help = dedent("""Select whether the reads matching the threshold
+        should be included or excluded. If included is chosen only matching
+        reads are kept. If excluded is chosen only the reads _not_ matching
+        the treshold are kept. Valid options: 'include' and 'exclude'.
+        """)
+        parser.add_argument('-m', '--matches', default="include",
+                            help=match_help)
 
         args = parser.parse_args()
-        read_stdin(args.score)
+        if args.matches not in ['include', 'exclude']:
+            sys.stderr.write("Wrong Argument.\
+            --matches needs to be 'include' or 'exclude'\n")
+        read_stdin(args.score, args.matches)
 
     except BrokenPipeError:
         # pipe error (e.g., when head is used)


### PR DESCRIPTION
The magicblast processing script now does two things more:

1. you can specify whether the reads that take our threshold are included in the output or whether these are excluded (closes #13)
2. Unmapped reads are now handled correctly too. If you want to include reads only if they map against the reference these reads are not written to `stdout`. If we want to exclude mapping reads they are printed.